### PR TITLE
reformatted link in Lantern

### DIFF
--- a/chapters/bizleg-case-studies/startups/Lantern.md
+++ b/chapters/bizleg-case-studies/startups/Lantern.md
@@ -68,7 +68,7 @@ N/A
 
 > Wikipedia?
 
-[Wikipedia: Lantern (software)](http://en.wikipedia.org/wiki/Lantern_(software))
+<a href="http://en.wikipedia.org/wiki/Lantern_(software)">Wikipedia: Lantern (software)</a>
 
 > Does your organization file any annual reports? Please include links to any relevant documents (i.e. 990, Annual Report, Year in Review, etc...)
 


### PR DESCRIPTION
The link was rendering correctly on github but not on the web version of gitbook. This link has a parenthesis at the end which interfered with markdown's bracket link notation []. Using html notation should fix the problem. The preview changes are rendering correctly on github.

refer to http://fossrit.github.io/HowToFOSS/chapters/bizleg-case-studies/startups/Lantern.html to see the actual link not rendering correctly