### PR TITLE
Fix invalid link/typo causing bug

### DIFF
--- a/src/chapters/bizleg-case-studies/fiscal-sponsorship/LinuxFoundation.md
+++ b/src/chapters/bizleg-case-studies/fiscal-sponsorship/LinuxFoundation.md
@@ -4,7 +4,7 @@ Profile: Linux Foundation
 ### Authors
 - [Matt Soucy (msoucy)](mailto:msoucy@csh.rit.edu)
 - [Liam Middlebrook (loothelion)](mailto:liammiddlebrook@gmail.com)
-- [Julien Eid (jeid64)](<mailto:jeid@csh.rit.edu)
+- [Julien Eid (jeid64)](mailto:jeid@csh.rit.edu)
 - [Aaron Herting (qwertos)](mailto:adh2380@rit.edu)
 
 


### PR DESCRIPTION
Only 1 character is removed so that links work the same